### PR TITLE
Fixing example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ String goldenRatioInPython = """
 # Approximate the golden ratio using the Fibonacci sequence.
 previous = 0
 current = 1
+iterations = 50
 for i in range(iterations):
     if task.cancel_requested:
         task.cancel()
@@ -111,8 +112,9 @@ try (Service python = env.python()) {
                 System.out.println("Progress: " + task.current + "/" + task.maximum);
                 break;
             case COMPLETION:
-                long numer = (Long) task.outputs.get("numer");
-                long denom = (Long) task.outputs.get("denom");
+                long numer = ((Number) task.outputs.get("numer")).longValue();
+                long denom = ((Number) task.outputs.get("denom")).longValue();
+
                 double ratio = (double) numer / denom;
                 System.out.println("Task complete. Result: " + numer + "/" + denom + " =~ " + ratio);
                 break;


### PR DESCRIPTION
`goldenRatioInPython` needs to define `iterations`, and the returned Integers can't be cast to Long (a bug?).