### PR TITLE
Do not consume potentially existing global conda settings

### DIFF
--- a/src/main/java/org/apposed/appose/mamba/Mamba.java
+++ b/src/main/java/org/apposed/appose/mamba/Mamba.java
@@ -424,7 +424,7 @@ class Mamba {
 	{
 		checkMambaInstalled();
 		runMamba("env", "create", "--prefix",
-				envDir.getAbsolutePath(), "-f", envYaml, "-y", "-vv" );
+				envDir.getAbsolutePath(), "-f", envYaml, "-y", "-vv", "--no-condarc" );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the flag "--no-condarc" to create environment command.

Reasoning:

When testing code that contained setting up a python env using a yml file on user machines, it turned out that, if the user had an installation on his machine, it could happen that the already existing global settings from that installation were used.
In that particular case, this lead to the defaults channel being given priority, which was blocked by the institute where he is working, even though this channel was not at all referenced in the yml file.
In order to avoid such unexpected situations, where already existing installations influence what happens during the set up of an environment, I suggest to add the "--no-condarc" flag to the creation of a new environment.

Alternatively, one could instead add the "--override-channels" flag.