### PR TITLE
Add PEP 735 dependency group support to UvBuilder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,8 +180,8 @@ The project provides type-safe builder classes for different environment types:
 
 **UvBuilder** - Fast Python virtual environments via uv
 - Created via `Appose.uv()` or `Appose.uv(source)`
-- Type-safe methods: `include(packages...)`, `python(version)`
-- Supports `requirements.txt` files
+- Type-safe methods: `include(packages...)`, `python(version)`, `group(groups...)`
+- Supports `requirements.txt` and `pyproject.toml`
 - Standard Python venv structure (no special activation needed)
 - Environment structure: `<envDir>/bin` (or `Scripts` on Windows)
 - Location: `org.apposed.appose.builder.UvBuilder`
@@ -228,6 +228,13 @@ Environment env = Appose.uv()
     .python("3.11")
     .include("numpy", "pandas", "matplotlib")
     .name("my-env")
+    .build();
+
+// uv builder with dependency groups
+Environment env = Appose.uv()
+    .content(pyprojectContent)
+    .scheme("pyproject.toml")
+    .group("appose")
     .build();
 
 // Dynamic builder (auto-detects)

--- a/src/main/java/org/apposed/appose/builder/UvBuilder.java
+++ b/src/main/java/org/apposed/appose/builder/UvBuilder.java
@@ -55,6 +55,7 @@ public final class UvBuilder extends BaseBuilder<UvBuilder> {
 
 	private String pythonVersion;
 	private final List<String> packages = new ArrayList<>();
+	private final List<String> groups = new ArrayList<>();
 
 	// -- UvBuilder methods --
 
@@ -80,6 +81,18 @@ public final class UvBuilder extends BaseBuilder<UvBuilder> {
 		return this;
 	}
 
+	/**
+	 * Adds PEP 735 dependency groups to install via {@code uv sync --group}.
+	 * Only supported with {@code pyproject.toml} scheme.
+	 *
+	 * @param groups Dependency group names defined in {@code [dependency-groups]}.
+	 * @return This builder instance, for fluent-style programming.
+	 */
+	public UvBuilder group(String... groups) {
+		this.groups.addAll(Arrays.asList(groups));
+		return this;
+	}
+
 	// -- Builder methods --
 
 	@Override
@@ -92,6 +105,7 @@ public final class UvBuilder extends BaseBuilder<UvBuilder> {
 		super.addStateFields(state);
 		state.put("pythonVersion", pythonVersion);
 		state.put("packages", packages);
+		if (!groups.isEmpty()) state.put("groups", groups);
 	}
 
 	@Override
@@ -136,6 +150,12 @@ public final class UvBuilder extends BaseBuilder<UvBuilder> {
 			}
 		}
 
+		// Validate groups are only used with pyproject.toml.
+		if (!groups.isEmpty() && !"pyproject.toml".equals(scheme == null ? null : scheme.name())) {
+			throw new IllegalArgumentException(
+				"Dependency groups are only supported with pyproject.toml scheme");
+		}
+
 		try {
 			// If the env state matches our current configuration,
 			// skip all package management and return immediately.
@@ -164,7 +184,7 @@ public final class UvBuilder extends BaseBuilder<UvBuilder> {
 					Files.write(pyprojectFile.toPath(), content.getBytes(StandardCharsets.UTF_8));
 
 					// Run uv sync to create .venv and install dependencies.
-					uv.sync(envDir, pythonVersion);
+					uv.sync(envDir, pythonVersion, groups);
 				} else {
 					// Handle requirements.txt - traditional venv + pip install.
 					// Create virtual environment if it doesn't exist.

--- a/src/main/java/org/apposed/appose/tool/Uv.java
+++ b/src/main/java/org/apposed/appose/tool/Uv.java
@@ -262,12 +262,18 @@ public class Uv extends Tool {
 	 * @throws InterruptedException If the current thread is interrupted.
 	 * @throws IllegalStateException if uv has not been installed
 	 */
-	public void sync(final File projectDir, String pythonVersion) throws IOException, InterruptedException {
+	public void sync(final File projectDir, String pythonVersion, List<String> groups) throws IOException, InterruptedException {
 		List<String> args = new ArrayList<>();
 		args.add("sync");
 		if (pythonVersion != null && !pythonVersion.isEmpty()) {
 			args.add("--python");
 			args.add(pythonVersion);
+		}
+		if (groups != null) {
+			for (String group : groups) {
+				args.add("--group");
+				args.add(group);
+			}
 		}
 
 		// Run uv sync with working directory set to projectDir.

--- a/src/test/java/org/apposed/appose/builder/UvBuilderTest.java
+++ b/src/test/java/org/apposed/appose/builder/UvBuilderTest.java
@@ -32,9 +32,18 @@ package org.apposed.appose.builder;
 import org.apposed.appose.Appose;
 import org.apposed.appose.Environment;
 import org.apposed.appose.TestBase;
+import org.apposed.appose.util.Json;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** End-to-end tests for {@link UvBuilder}. */
 public class UvBuilderTest extends TestBase {
@@ -70,5 +79,58 @@ public class UvBuilderTest extends TestBase {
 			.logDebug()
 			.build();
 		cowsayAndAssert(env, "pyproject");
+	}
+
+	@Test
+	public void testUvPyprojectWithGroup() throws Exception {
+		Environment env = Appose
+			.uv("src/test/resources/envs/cowsay-pyproject-groups.toml")
+			.group("cowsay")
+			.base("target/envs/uv-cowsay-groups")
+			.logDebug()
+			.build();
+		cowsayAndAssert(env, "groups");
+	}
+
+	@Test
+	public void testUvGroupRejectsWithoutPyproject() {
+		assertThrows(IllegalArgumentException.class, () ->
+			Appose.uv()
+				.content("appose\n")
+				.group("cowsay")
+				.base("target/envs/uv-group-no-pyproject")
+				.build());
+	}
+
+	@Test
+	public void testUvStateNoGroupField() throws Exception {
+		Environment env = Appose
+			.uv("src/test/resources/envs/cowsay-pyproject.toml")
+			.base("target/envs/uv-state-no-groups")
+			.logDebug()
+			.build();
+		File apposeJson = new File(env.base(), "appose.json");
+		assertTrue(apposeJson.isFile(), "appose.json should exist");
+		String json = new String(Files.readAllBytes(apposeJson.toPath()), StandardCharsets.UTF_8);
+		@SuppressWarnings("unchecked")
+		java.util.Map<String, Object> state = (java.util.Map<String, Object>) Json.parseJson(json);
+		assertFalse(state.containsKey("groups"), "appose.json should not contain 'groups' when none specified");
+		assertNotNull(state.get("packages"), "appose.json should contain 'packages'");
+	}
+
+	@Test
+	public void testUvStateGroupFieldPresent() throws Exception {
+		Environment env = Appose
+			.uv("src/test/resources/envs/cowsay-pyproject-groups.toml")
+			.group("cowsay")
+			.base("target/envs/uv-state-with-groups")
+			.logDebug()
+			.build();
+		File apposeJson = new File(env.base(), "appose.json");
+		assertTrue(apposeJson.isFile(), "appose.json should exist");
+		String json = new String(Files.readAllBytes(apposeJson.toPath()), StandardCharsets.UTF_8);
+		@SuppressWarnings("unchecked")
+		java.util.Map<String, Object> state = (java.util.Map<String, Object>) Json.parseJson(json);
+		assertTrue(state.containsKey("groups"), "appose.json should contain 'groups' when specified");
 	}
 }

--- a/src/test/resources/envs/cowsay-pyproject-groups.toml
+++ b/src/test/resources/envs/cowsay-pyproject-groups.toml
@@ -1,0 +1,13 @@
+[project]
+name = "cowsay-groups-test"
+version = "0.1.0"
+description = "Test project for cowsay with dependency groups"
+requires-python = ">=3.10"
+dependencies = [
+    "appose>=0.1.0",
+]
+
+[dependency-groups]
+cowsay = [
+    "cowsay>=6.0",
+]


### PR DESCRIPTION
- Add `group(String...)` method to `UvBuilder` that maps to `uv sync --group`, enabling PEP 735 dependency groups selection
- Groups are tracked in `appose.json` only when non-empty, preserving backward compatibility with existing environments
- Validate that `group()` is only used with `pyproject.toml` scheme

closes apposed/appose#32

## Example

```java
Environment env = Appose.uv()
    .content(pyprojectContent)
    .scheme("pyproject.toml")
    .group("appose")
    .group("cowsay")  # support multiple groups
    .build();
```

## Test plan

- `testUvPyprojectWithGroup`: builds env with `--group cowsay` and verifies cowsay is available
- `testUvGroupRejectsWithoutPyproject`: confirms `IllegalArgumentException` when using `group()` without `pyproject.toml`
- `testUvStateNoGroupField`: verifies `appose.json` has no groups field when none specified (backward compat)
- `testUvStateGroupFieldPresent`: verifies `appose.json` contains groups when specified

All 7 `UvBuilderTest` tests pass